### PR TITLE
feat: Add warning for very large search results

### DIFF
--- a/api_client.py
+++ b/api_client.py
@@ -92,6 +92,17 @@ def rechercher_geographiquement_entreprises(lat, long, radius, api_params):
         elapsed_time_page1 = time.time() - start_time_page1
         st.write(f"Page 1 ({len(results_page1)} rés.) récupérée en {elapsed_time_page1:.2f}s. Total pages estimé: {total_pages}, Total résultats API: {total_results}")
 
+        if total_pages >= 400 and total_results >= 10000:
+            st.warning(
+                f"⚠️ Votre recherche a retourné un très grand nombre de résultats (Total pages estimé: {total_pages}, Total résultats API: {total_results}). "
+                "Pour une exploration plus ciblée et pour vous assurer de ne pas manquer d'entreprises pertinentes en raison des limites d'affichage "
+                "(l'application ne peut traiter qu'un nombre limité de pages au-delà de la première), "
+                "veuillez envisager de :"
+                "\n- Réduire le rayon de recherche."
+                "\n- Affiner davantage votre sélection en utilisant des codes NAF spécifiques."
+                "\n\nCela permettra d'obtenir une liste plus gérable et pertinente."
+            )
+
         # === Étape 2: Vérifier si d'autres pages sont nécessaires ===
         if total_pages < 2:
             status.update(label=f"Recherche terminée. {len(entreprises_detaillees)} entreprises trouvées ({total_pages} page).", state="complete")


### PR DESCRIPTION
This commit introduces a user-facing warning when an API search yields a very large number of results (specifically, when estimated total pages >= 400 and total API results >= 10000).

The warning is displayed directly after the initial API call in `api_client.py` (within the `rechercher_geographiquement_entreprises` function) and advises you to:
- Reduce the geographical search radius.
- Refine your search using specific NAF codes.

This aims to improve your experience by guiding you towards more manageable and relevant search queries, especially given that the application has practical limits on how many results it can process and display from the API.